### PR TITLE
Fix: Test Failure w/Established Environment

### DIFF
--- a/force-app/main/default/classes/BenchmarkJobTest.cls
+++ b/force-app/main/default/classes/BenchmarkJobTest.cls
@@ -228,6 +228,9 @@ private class BenchmarkJobTest {
 
 	@IsTest
 	static void shouldNotLaunchJobIfNoJobs() {
+		// Inject an empty list of metadata to be processed
+		BenchmarkJobSettingSelector.settings = new Map<String, BenchmarkJobSetting__mdt>();
+
 		Test.startTest();
 		new BenchmarkJob()?.launch();
 		Test.stopTest();


### PR DESCRIPTION
Updated the `shouldNotLaunchJobIfNoJobs` test method to directly inject an empty map of settings. This prevents unexpected test behavior/failures in subscriber environments w/live metadata.