### PR TITLE
Fix: Entity Definition Validation Rule

### DIFF
--- a/force-app/main/default/objects/BenchmarkJobSetting__mdt/validationRules/ShouldOnlyHaveOneSObjectTypeValue.validationRule-meta.xml
+++ b/force-app/main/default/objects/BenchmarkJobSetting__mdt/validationRules/ShouldOnlyHaveOneSObjectTypeValue.validationRule-meta.xml
@@ -2,12 +2,10 @@
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ShouldOnlyHaveOneSObjectTypeValue</fullName>
     <active>true</active>
-    <description
-	>Developers should either specify an SObjectType via the dropdown, or the free text field - but not both</description>
-    <errorConditionFormula>OR(
-        NOT(ISBLANK(SObjectType__r.QualifiedApiName)) &amp;&amp; NOT(ISBLANK(SObjectTypeName__c)),
-        ISBLANK(SObjectType__r.QualifiedApiName) &amp;&amp; ISBLANK(SObjectTypeName__c)
-        )</errorConditionFormula>
+    <description>Developers can either specify an SObjectType via the dropdown, or the free text
+        field - but not both</description>
+    <errorConditionFormula>NOT(ISBLANK(SObjectType__r.QualifiedApiName)) &amp;&amp;
+        NOT(ISBLANK(SObjectTypeName__c))</errorConditionFormula>
     <errorDisplayField>SObjectType__c</errorDisplayField>
     <errorMessage
 	>Please specify an SObjectType, using either the dropdown or the free-text field - but not both.</errorMessage>

--- a/force-app/main/default/objects/BenchmarkJobSetting__mdt/validationRules/ShouldOnlyHaveOneSObjectTypeValue.validationRule-meta.xml
+++ b/force-app/main/default/objects/BenchmarkJobSetting__mdt/validationRules/ShouldOnlyHaveOneSObjectTypeValue.validationRule-meta.xml
@@ -5,9 +5,9 @@
     <description
 	>Developers should either specify an SObjectType via the dropdown, or the free text field - but not both</description>
     <errorConditionFormula>OR(
-  NOT(ISBLANK(TEXT(SObjectType__c))) &amp;&amp; NOT(ISBLANK(SObjectTypeName__c)),
-  ISBLANK(TEXT(SObjectType__c)) &amp;&amp; ISBLANK(SObjectTypeName__c)
-)</errorConditionFormula>
+        NOT(ISBLANK(SObjectType__r.QualifiedApiName)) &amp;&amp; NOT(ISBLANK(SObjectTypeName__c)),
+        ISBLANK(SObjectType__r.QualifiedApiName) &amp;&amp; ISBLANK(SObjectTypeName__c)
+        )</errorConditionFormula>
     <errorDisplayField>SObjectType__c</errorDisplayField>
     <errorMessage
 	>Please specify an SObjectType, using either the dropdown or the free-text field - but not both.</errorMessage>


### PR DESCRIPTION
Tweaked the validation rule which guards against both the `SObjectType__c` entity definition picklist, and the `SObjectTypeName__c` free-text field being populated at the same time. Apprantly, `NOT(ISBLANK(TEXT({{entity_definition_picklist_field}})) ` can produce some unexpected results that weren't picked up with earlier testing. 

Also removes the requirement for _either_ of these values to be filled in; it's an optional field, after all.